### PR TITLE
fix: default year should look at month, not day

### DIFF
--- a/aoc/gen/__main__.py
+++ b/aoc/gen/__main__.py
@@ -49,10 +49,10 @@ def write_file(filename, content):
         info(filename, False)
         return
 
-# get de default year
+# get the default year
 def default_year():
     today = date.today()
-    if today.day == 12:
+    if today.month == 12:
         return today.year
     else:
         return today.year - 1


### PR DESCRIPTION
Hi, I've been using your python starter for this year's AOC and didn't set the AOC_YEAR environment variable, so I got last year's inputs! This should fix it 😅 